### PR TITLE
remove: package_resources to use importlib_metadata instead

### DIFF
--- a/cid/__init__.py
+++ b/cid/__init__.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib_metadata import distribution
 
 
-__version__ = pkg_resources.get_distribution('django-cid').version
+__version__ = distribution('django-cid').version

--- a/cid/__init__.py
+++ b/cid/__init__.py
@@ -1,4 +1,11 @@
-from importlib_metadata import distribution
+import sys
 
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version, PackageNotFoundError
+else:
+    from importlib_metadata import version, PackageNotFoundError
 
-__version__ = distribution('django-cid').version
+try:
+    __version__ = version('django-cid')
+except PackageNotFoundError:
+    raise PackageNotFoundError("The package `django-cid` is not properly installed.")


### PR DESCRIPTION
https://setuptools.pypa.io/en/latest/pkg_resources.html

>Use of pkg_resources is deprecated in favor of importlib.resources, importlib.metadata and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Some useful APIs are also provided by [packaging](https://pypi.org/project/packaging) (e.g. requirements and version parsing). Users should refrain from new usage of pkg_resources and should work to port to importlib-based solutions.