### PR TITLE
fix: Fixes de pkg_resources usage with modern importlib

### DIFF
--- a/cid/__init__.py
+++ b/cid/__init__.py
@@ -1,4 +1,8 @@
-import pkg_resources
+import sys
 
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version
+else:
+    from importlib_metadata import version
 
-__version__ = pkg_resources.get_distribution('django-cid').version
+__version__ = version('django-cid')


### PR DESCRIPTION
This PR fixes an [issue](https://github.com/Polyconseil/django-cid/issues/65) with the `pkg_resources` package missing that was causing installation errors. 

The PR updates the `django-cid` package to use the `importlib.metadata` on Python3.8+ or the backported `importlib_metadata` module for older versions. This ensures compatibility with future Python releases.