### PR TITLE
[INFLDP-1009] feat: add settings for cid positioning

### DIFF
--- a/cid/cursor.py
+++ b/cid/cursor.py
@@ -4,6 +4,7 @@ from .locals import get_cid
 
 
 DEFAULT_CID_SQL_COMMENT_TEMPLATE = 'cid: {cid}'
+DEFAULT_SQL_STATEMENT_TEMPLATE = '/* {cid} */\n{sql}'
 
 
 class CidCursorWrapper:
@@ -31,12 +32,16 @@ class CidCursorWrapper:
         cid_sql_template = getattr(
             settings, 'CID_SQL_COMMENT_TEMPLATE', DEFAULT_CID_SQL_COMMENT_TEMPLATE
         )
+        sql_statement_template = getattr(
+            settings, 'CID_SQL_STATEMENT_TEMPLATE', DEFAULT_SQL_STATEMENT_TEMPLATE
+        )
         cid = get_cid()
         if not cid:
             return sql
         cid = cid.replace('/*', r'\/\*').replace('*/', r'\*\/')
         cid = cid_sql_template.format(cid=cid)
-        return f"/* {cid} */\n{sql}"
+        statement = sql_statement_template.format(cid=cid, sql=sql)
+        return statement
 
     # The following methods cannot be implemented in __getattr__, because the
     # code must run when the method is invoked, not just when it is accessed.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst', encoding="utf-8") as fp:
 
 setup(
     name='django-cid',
-    version='2.4.dev0',
+    version='2.5.dev0',
     description="""Correlation IDs in Django for debugging requests""",
     long_description=readme,
     author='Snowball One',

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -33,6 +33,16 @@ class TestCidCursor(TestCase):
             self.cursor_wrapper.add_comment("SELECT 1;")
         )
 
+    @override_settings(CID_SQL_STATEMENT_TEMPLATE='{sql}\n/* {cid} */')
+    @mock.patch('cid.cursor.get_cid')
+    def test_adds_comment_with_statement_template_setting_overriden(self, get_cid):
+        get_cid.return_value = 'testing-cursor-after-sql-statement'
+        expected = "SELECT 1;\n/* cid: testing-cursor-after-sql-statement */"
+        self.assertEqual(
+            expected,
+            self.cursor_wrapper.add_comment("SELECT 1;")
+        )
+
     @mock.patch('cid.cursor.get_cid')
     def test_no_comment_when_cid_is_none(self, get_cid):
         get_cid.return_value = None


### PR DESCRIPTION
# Description
Adds a setting to define the correlation id placement injected in the SQL statement.

The main motivation for this was due to OpenTelemetry instrumentation for psycopg2 which uses the first word to define which database operation is being performed and the operation was being defined to the comment marker /* due to the comment in the beginning.

Same proposal also opened on django-cid repo: https://github.com/Polyconseil/django-cid/pull/68

# Tests
```
» pytest                                   [14:53:32] 
================================================== test session starts ===================================================
platform linux -- Python 3.8.10, pytest-7.4.0, pluggy-1.2.0
rootdir: /opt/loggi/django-cid-loggi
plugins: django-4.5.2
collected 20 items                                                                                                       

tests/test_context_processors.py ..                                                                                [ 10%]
tests/test_cursor.py .......                                                                                       [ 45%]
tests/test_locals.py ...                                                                                           [ 60%]
tests/test_middleware.py ........                                                                                  [100%]

=================================================== 20 passed in 0.45s ===================================================
```